### PR TITLE
Fix: Move dotenv to dependencies and release v0.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coderide/mcp",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Model Context Protocol server for CodeRide, task management redesigned for AI",
   "main": "dist/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -28,12 +28,12 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "latest",
     "axios": "^1.6.0",
+    "dotenv": "^16.5.0",
     "nanoid": "^5.1.3",
     "zod": "^3.20.0"
   },
   "devDependencies": {
     "@types/node": "^20.17.47",
-    "dotenv": "^16.5.0",
     "ts-node": "^10.9.1",
     "typescript": "^5.2.2"
   }


### PR DESCRIPTION
This PR addresses an issue where `dotenv` was incorrectly listed in `devDependencies`, causing `MODULE_NOT_FOUND` errors when running the package via `npx`.

Changes:
- Moved `dotenv` from `devDependencies` to `dependencies` in `package.json`.
- Bumped package version to `0.3.1`.