### PR TITLE
feat(mcp): Add three new MCP tools for project and task management

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,10 @@ import { GetProjectTool } from './tools/get-project';
 import { UpdateProjectTool } from './tools/update-project';
 import { GetPromptTool } from './tools/get-prompt';
 import { StartProjectTool } from './tools/start-project';
+// New MCP tools
+import { ProjectListTool } from './tools/project-list';
+import { TaskListTool } from './tools/task-list';
+import { NextTaskTool } from './tools/next-task';
 // Deactivated tools (commented out)
 // import { CreateTaskTool } from './tools/create-task';
 // import { CreateProjectTool } from './tools/create-project';
@@ -79,6 +83,10 @@ class CodeRideServer {
       new GetProjectTool(),
       new UpdateTaskTool(),
       new UpdateProjectTool(),
+      // New MCP tools
+      new ProjectListTool(),
+      new TaskListTool(),
+      new NextTaskTool(),
       // Deactivated tools
       // new CreateTaskTool(),
       // new CreateProjectTool(),

--- a/src/tools/next-task.ts
+++ b/src/tools/next-task.ts
@@ -1,0 +1,131 @@
+/**
+ * Next Task Tool
+ * 
+ * Retrieves the next task in sequence from the CodeRide API
+ */
+import { z } from 'zod';
+import { BaseTool, MCPToolDefinition, ToolAnnotations } from '../utils/base-tool';
+import { apiClient, NextTaskApiResponse } from '../utils/api-client';
+import { logger } from '../utils/logger';
+
+/**
+ * Schema for the next-task tool input
+ */
+const NextTaskSchema = z.object({
+  // Task number (e.g., "CDB-23")
+  taskNumber: z.string({
+    required_error: "Task number is required"
+  }).regex(/^[A-Z]{3}-\d+$/, { message: "Task number must be in the format ABC-123 (e.g., CDB-23)." }),
+}).strict();
+
+/**
+ * Type for the next-task tool input
+ */
+type NextTaskInput = z.infer<typeof NextTaskSchema>;
+
+/**
+ * Next Task Tool Implementation
+ */
+export class NextTaskTool extends BaseTool<typeof NextTaskSchema> {
+  readonly name = 'next_task';
+  readonly description = "Retrieves the next task in sequence based on the current task number (e.g., CDB-23 → CDB-24). This is useful for finding the next task that needs to be done in a project workflow.";
+  readonly zodSchema = NextTaskSchema;
+  readonly annotations: ToolAnnotations = {
+    title: "Next Task",
+    readOnlyHint: true,
+    openWorldHint: true, // Interacts with an external API
+  };
+
+  /**
+   * Returns the full tool definition conforming to MCP.
+   */
+  getMCPToolDefinition(): MCPToolDefinition {
+    return {
+      name: this.name,
+      description: this.description,
+      annotations: this.annotations,
+      inputSchema: {
+        type: "object",
+        properties: {
+          taskNumber: {
+            type: "string",
+            pattern: "^[A-Z]{3}-\\d+$",
+            description: "The current task number to find the next task for (e.g., 'CDB-23'). Must follow the format: three uppercase letters, a hyphen, and one or more digits."
+          }
+        },
+        required: ["taskNumber"],
+        additionalProperties: false
+      }
+    };
+  }
+
+  /**
+   * Execute the next-task tool
+   */
+  async execute(input: NextTaskInput): Promise<unknown> {
+    logger.info('Executing next-task tool', input);
+
+    try {
+      const url = `/task/number/${input.taskNumber}/next`;
+      logger.debug(`Making GET request to: ${url}`);
+      
+      const responseData = await apiClient.get<NextTaskApiResponse>(url) as unknown as NextTaskApiResponse;
+      
+      if (!responseData) {
+        logger.warn(`No next task found for ${input.taskNumber} from ${url}`);
+        return {
+          isError: true,
+          content: [{ type: "text", text: `No next task found after '${input.taskNumber}'` }]
+        };
+      }
+      
+      // Extract project slug and calculate sequence info
+      const currentProjectSlug = input.taskNumber.split('-')[0];
+      const currentNumber = parseInt(input.taskNumber.split('-')[1]);
+      const nextNumber = currentNumber + 1;
+      
+      // Return formatted next task details
+      return {
+        currentTask: {
+          number: input.taskNumber,
+          projectSlug: currentProjectSlug,
+          sequenceNumber: currentNumber
+        },
+        nextTask: {
+          number: responseData.number,
+          title: responseData.title,
+          description: responseData.description,
+          status: responseData.status,
+          priority: responseData.priority,
+          dueDate: responseData.dueDate,
+          assigneeEmail: responseData.assigneeEmail,
+          sequenceNumber: nextNumber,
+          hasContext: !!responseData.context,
+          hasInstructions: !!responseData.instructions
+        },
+        sequenceInfo: {
+          projectSlug: currentProjectSlug,
+          progression: `${input.taskNumber} → ${responseData.number}`,
+          increment: 1
+        }
+      };
+    } catch (error) {
+      const errorMessage = (error instanceof Error) ? error.message : 'An unknown error occurred';
+      logger.error(`Error in next-task tool: ${errorMessage}`, error instanceof Error ? error : undefined);
+      
+      // Provide more specific error messages based on common scenarios
+      let userFriendlyMessage = errorMessage;
+      if (errorMessage.includes('not found')) {
+        const projectSlug = input.taskNumber.split('-')[0];
+        const currentNumber = parseInt(input.taskNumber.split('-')[1]);
+        const expectedNext = `${projectSlug}-${currentNumber + 1}`;
+        userFriendlyMessage = `Next task '${expectedNext}' not found. This might be the last task in the project or the next task hasn't been created yet.`;
+      }
+      
+      return {
+        isError: true,
+        content: [{ type: "text", text: userFriendlyMessage }]
+      };
+    }
+  }
+}

--- a/src/tools/project-list.ts
+++ b/src/tools/project-list.ts
@@ -1,0 +1,97 @@
+/**
+ * Project List Tool
+ * 
+ * Lists all projects in the user workspace from the CodeRide API
+ */
+import { z } from 'zod';
+import { BaseTool, MCPToolDefinition, ToolAnnotations } from '../utils/base-tool';
+import { apiClient, ProjectListApiResponse } from '../utils/api-client';
+import { logger } from '../utils/logger';
+
+/**
+ * Schema for the project-list tool input
+ * No input parameters required - workspace is extracted from API key
+ */
+const ProjectListSchema = z.object({}).strict();
+
+/**
+ * Type for the project-list tool input
+ */
+type ProjectListInput = z.infer<typeof ProjectListSchema>;
+
+/**
+ * Project List Tool Implementation
+ */
+export class ProjectListTool extends BaseTool<typeof ProjectListSchema> {
+  readonly name = 'project_list';
+  readonly description = "Lists all projects in the user workspace. No input parameters required as the workspace is automatically determined from the API key authentication.";
+  readonly zodSchema = ProjectListSchema;
+  readonly annotations: ToolAnnotations = {
+    title: "Project List",
+    readOnlyHint: true,
+    openWorldHint: true, // Interacts with an external API
+  };
+
+  /**
+   * Returns the full tool definition conforming to MCP.
+   */
+  getMCPToolDefinition(): MCPToolDefinition {
+    return {
+      name: this.name,
+      description: this.description,
+      annotations: this.annotations,
+      inputSchema: {
+        type: "object",
+        properties: {},
+        required: [],
+        additionalProperties: false
+      }
+    };
+  }
+
+  /**
+   * Execute the project-list tool
+   */
+  async execute(input: ProjectListInput): Promise<unknown> {
+    logger.info('Executing project-list tool', input);
+
+    try {
+      const url = `/project/list`;
+      logger.debug(`Making GET request to: ${url}`);
+      
+      const responseData = await apiClient.get<ProjectListApiResponse[]>(url) as unknown as ProjectListApiResponse[];
+      
+      if (!responseData || !Array.isArray(responseData)) {
+        logger.warn(`No projects found or invalid response format from ${url}`);
+        return { projects: [] };
+      }
+      
+      // Return formatted project list
+      return {
+        projects: responseData.map(project => ({
+          id: project.id,
+          name: project.name,
+          description: project.description,
+          slug: project.slug,
+          icon: project.icon,
+          status: project.status || 'unknown',
+          workspaceId: project.workspaceId,
+          createdAt: project.createdAt,
+          workspace: {
+            id: project.workspace?.id || '',
+            name: project.workspace?.name || ''
+          }
+        })),
+        totalCount: responseData.length
+      };
+    } catch (error) {
+      const errorMessage = (error instanceof Error) ? error.message : 'An unknown error occurred';
+      logger.error(`Error in project-list tool: ${errorMessage}`, error instanceof Error ? error : undefined);
+      
+      return {
+        isError: true,
+        content: [{ type: "text", text: errorMessage }]
+      };
+    }
+  }
+}

--- a/src/tools/task-list.ts
+++ b/src/tools/task-list.ts
@@ -1,0 +1,131 @@
+/**
+ * Task List Tool
+ * 
+ * Lists all tasks within a project by slug from the CodeRide API
+ */
+import { z } from 'zod';
+import { BaseTool, MCPToolDefinition, ToolAnnotations } from '../utils/base-tool';
+import { apiClient, TaskListApiResponse } from '../utils/api-client';
+import { logger } from '../utils/logger';
+
+/**
+ * Schema for the task-list tool input
+ */
+const TaskListSchema = z.object({
+  // Project slug (URL-friendly identifier)
+  slug: z.string({
+    required_error: "Project slug is required"
+  })
+    .regex(/^[A-Z]{3}$/, { message: "Project slug must be three uppercase letters (e.g., CDB)." }),
+}).strict();
+
+/**
+ * Type for the task-list tool input
+ */
+type TaskListInput = z.infer<typeof TaskListSchema>;
+
+/**
+ * Task List Tool Implementation
+ */
+export class TaskListTool extends BaseTool<typeof TaskListSchema> {
+  readonly name = 'task_list';
+  readonly description = "Lists all tasks within a project using the project slug (e.g., 'CDB'). Returns tasks organized by status columns with their order and current status.";
+  readonly zodSchema = TaskListSchema;
+  readonly annotations: ToolAnnotations = {
+    title: "Task List",
+    readOnlyHint: true,
+    openWorldHint: true, // Interacts with an external API
+  };
+
+  /**
+   * Returns the full tool definition conforming to MCP.
+   */
+  getMCPToolDefinition(): MCPToolDefinition {
+    return {
+      name: this.name,
+      description: this.description,
+      annotations: this.annotations,
+      inputSchema: {
+        type: "object",
+        properties: {
+          slug: {
+            type: "string",
+            pattern: "^[A-Z]{3}$",
+            description: "The unique three-letter uppercase identifier for the project (e.g., 'CDB')."
+          }
+        },
+        required: ["slug"],
+        additionalProperties: false
+      }
+    };
+  }
+
+  /**
+   * Execute the task-list tool
+   */
+  async execute(input: TaskListInput): Promise<unknown> {
+    logger.info('Executing task-list tool', input);
+
+    try {
+      const url = `/task/project/slug/${input.slug}`;
+      logger.debug(`Making GET request to: ${url}`);
+      
+      const responseData = await apiClient.get<TaskListApiResponse>(url) as unknown as TaskListApiResponse;
+      
+      if (!responseData) {
+        logger.warn(`No project found or invalid response format from ${url}`);
+        return {
+          isError: true,
+          content: [{ type: "text", text: `Project with slug '${input.slug}' not found` }]
+        };
+      }
+      
+      // Calculate total task count across all columns
+      const totalTasks = responseData.columns?.reduce((total, column) => total + (column.tasks?.length || 0), 0) || 0;
+      
+      // Return formatted task list with project info and organized tasks
+      return {
+        project: {
+          id: responseData.id,
+          name: responseData.name,
+          slug: responseData.slug,
+          status: responseData.status
+        },
+        taskSummary: {
+          totalTasks,
+          statusBreakdown: responseData.columns?.map(column => ({
+            status: column.id,
+            name: column.name,
+            count: column.tasks?.length || 0
+          })) || []
+        },
+        tasksByStatus: responseData.columns?.map(column => ({
+          status: column.id,
+          name: column.name,
+          tasks: column.tasks?.map(task => ({
+            number: task.number,
+            title: task.title,
+            description: task.description,
+            status: task.status,
+            priority: task.priority,
+            position: task.position,
+            dueDate: task.dueDate,
+            assigneeEmail: task.assigneeEmail,
+            assigneeName: task.assigneeName,
+            createdAt: task.createdAt,
+            hasContext: !!task.context,
+            hasInstructions: !!task.instructions
+          })) || []
+        })) || []
+      };
+    } catch (error) {
+      const errorMessage = (error instanceof Error) ? error.message : 'An unknown error occurred';
+      logger.error(`Error in task-list tool: ${errorMessage}`, error instanceof Error ? error : undefined);
+      
+      return {
+        isError: true,
+        content: [{ type: "text", text: errorMessage }]
+      };
+    }
+  }
+}

--- a/src/utils/api-client.ts
+++ b/src/utils/api-client.ts
@@ -75,6 +75,64 @@ export interface StartProjectApiResponse {
   [key: string]: any;
 }
 
+// --- New API Response Types for MCP Tools ---
+
+export interface ProjectListApiResponse {
+  id: string;
+  name: string;
+  description: string;
+  workspaceId: string;
+  createdAt: string;
+  icon: string;
+  slug: string;
+  status?: string; // Project status field
+  workspace: {
+    id: string;
+    name: string;
+  };
+}
+
+export interface TaskListApiResponse {
+  id: string;
+  name: string;
+  slug: string;
+  workspaceId: string;
+  status: string;
+  columns: Array<{
+    id: string; // 'to-do', 'in-progress', 'in-review', 'done'
+    name: string;
+    tasks: Array<{
+      id: string;
+      title: string;
+      number: string;
+      description: string;
+      status: string;
+      priority: string;
+      dueDate: string | null;
+      createdAt: string;
+      position: number;
+      userEmail: string | null;
+      assigneeName: string | null;
+      assigneeEmail: string | null;
+      projectId: string;
+      context: any;
+      instructions: any;
+    }>;
+  }>;
+}
+
+export interface NextTaskApiResponse {
+  number: string;
+  title: string;
+  description: string;
+  status: string;
+  priority: string;
+  dueDate: string | null;
+  assigneeEmail: string | null;
+  context: any;
+  instructions: any;
+}
+
 
 // Custom error class for API errors
 export class ApiError extends Error {


### PR DESCRIPTION
This PR adds three new MCP tools: project_list, task_list, and next_task. All tools are implemented with TypeScript, Zod validation, and comprehensive error handling. Ready for testing once backend endpoints are implemented.